### PR TITLE
Expose binPath

### DIFF
--- a/wkhtmltopdf.go
+++ b/wkhtmltopdf.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-var binPath string //the cached paths as used by findPath()
+var BinPath string //the cached paths as used by findPath()
 
 // Page is the input struct for each page
 type Page struct {
@@ -198,8 +198,8 @@ func (pdfg *PDFGenerator) WriteFile(filename string) error {
 //a running program once it has been found
 func (pdfg *PDFGenerator) findPath() error {
 	const exe = "wkhtmltopdf"
-	if binPath != "" {
-		pdfg.binPath = binPath
+	if BinPath != "" {
+		pdfg.binPath = BinPath
 		return nil
 	}
 	exeDir, err := filepath.Abs(filepath.Dir(os.Args[0]))
@@ -208,13 +208,13 @@ func (pdfg *PDFGenerator) findPath() error {
 	}
 	path, err := exec.LookPath(filepath.Join(exeDir, exe))
 	if err == nil && path != "" {
-		binPath = path
+		BinPath = path
 		pdfg.binPath = path
 		return nil
 	}
 	path, err = exec.LookPath(exe)
 	if err == nil && path != "" {
-		binPath = path
+		BinPath = path
 		pdfg.binPath = path
 		return nil
 	}
@@ -224,7 +224,7 @@ func (pdfg *PDFGenerator) findPath() error {
 	}
 	path, err = exec.LookPath(filepath.Join(dir, exe))
 	if err == nil && path != "" {
-		binPath = path
+		BinPath = path
 		pdfg.binPath = path
 		return nil
 	}

--- a/wkhtmltopdf.go
+++ b/wkhtmltopdf.go
@@ -21,7 +21,7 @@ func SetPath(path string) {
 }
 
 // GetPath gets the path to wkhtmltopdf
-func GetPath() {
+func GetPath() string {
 	return binPath
 }
 

--- a/wkhtmltopdf.go
+++ b/wkhtmltopdf.go
@@ -13,7 +13,17 @@ import (
 	"strings"
 )
 
-var BinPath string //the cached paths as used by findPath()
+var binPath string //the cached paths as used by findPath()
+
+// SetPath sets the path to wkhtmltopdf
+func SetPath(path string) {
+	binPath = path
+}
+
+// GetPath gets the path to wkhtmltopdf
+func GetPath() {
+	return binPath
+}
 
 // Page is the input struct for each page
 type Page struct {
@@ -198,8 +208,8 @@ func (pdfg *PDFGenerator) WriteFile(filename string) error {
 //a running program once it has been found
 func (pdfg *PDFGenerator) findPath() error {
 	const exe = "wkhtmltopdf"
-	if BinPath != "" {
-		pdfg.binPath = BinPath
+	if binPath != "" {
+		pdfg.binPath = binPath
 		return nil
 	}
 	exeDir, err := filepath.Abs(filepath.Dir(os.Args[0]))
@@ -208,13 +218,13 @@ func (pdfg *PDFGenerator) findPath() error {
 	}
 	path, err := exec.LookPath(filepath.Join(exeDir, exe))
 	if err == nil && path != "" {
-		BinPath = path
+		binPath = path
 		pdfg.binPath = path
 		return nil
 	}
 	path, err = exec.LookPath(exe)
 	if err == nil && path != "" {
-		BinPath = path
+		binPath = path
 		pdfg.binPath = path
 		return nil
 	}
@@ -224,7 +234,7 @@ func (pdfg *PDFGenerator) findPath() error {
 	}
 	path, err = exec.LookPath(filepath.Join(dir, exe))
 	if err == nil && path != "" {
-		BinPath = path
+		binPath = path
 		pdfg.binPath = path
 		return nil
 	}


### PR DESCRIPTION
Thanks for your useful product. I'd like to expose `binPath` to set specific absolute path.

I'm trying to use `go-wkhtmltopdf` for my own CLI tool. This tool bundles `wkhtmltopdf` binary in its local directory to make installing easier. So it uses the `wkhtmltopdf` that is not in `PATH`.


