### PR TITLE
Remove superfluous space in DisableJavascript option

### DIFF
--- a/options.go
+++ b/options.go
@@ -322,7 +322,7 @@ func newPageOptions() pageOptions {
 		EnableForms:               boolOption{option: "enable-forms"},
 		NoImages:                  boolOption{option: "no-images"},
 		DisableInternalLinks:      boolOption{option: "disable-internal-links"},
-		DisableJavascript:         boolOption{option: "disable-javascript "},
+		DisableJavascript:         boolOption{option: "disable-javascript"},
 		JavascriptDelay:           uintOption{option: "javascript-delay"},
 		LoadErrorHandling:         stringOption{option: "load-error-handling"},
 		LoadMediaErrorHandling:    stringOption{option: "load-media-error-handling"},


### PR DESCRIPTION
The string for the "DisableJavascript" option ("--disable-javascript"
for wkhtmltopdf) contained a superfluous space character, causing
wkhtmltopdf to complain about a non-existing option.