### PR TITLE
Updating "Zoom" parameter in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ func ExampleNewPDFGenerator() {
 	// Set options for this page
 	page.FooterRight.Set("[page]")
 	page.FooterFontSize.Set(10)
-	page.Zoom.Set(95.50)
+	page.Zoom.Set(0.95)
 
 	// Add to document
 	pdfg.AddPage(page)

--- a/simplesample_test.go
+++ b/simplesample_test.go
@@ -26,7 +26,7 @@ func ExampleNewPDFGenerator() {
 	// Set options for this page
 	page.FooterRight.Set("[page]")
 	page.FooterFontSize.Set(10)
-	page.Zoom.Set(95.50)
+	page.Zoom.Set(0.95)
 
 	// Add to document
 	pdfg.AddPage(page)


### PR DESCRIPTION
Clarifies the usage for the zoom parameter on the page options. The current sample zooms the page in to 9550%