### PR TITLE
Use of exec.ErrDot requires Go 1.19+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SebastiaanKlippert/go-wkhtmltopdf
 
-go 1.18
+go 1.19
 
 require github.com/stretchr/testify v1.7.1
 


### PR DESCRIPTION
Howdy, and thanks for providing this module!

`exec.ErrDot` was added to Go in version 1.19. Because this module has a dependency on that sentinel error, specifying the minimum Go version in the mod file helps consumers know the minimum supported Go version. (You may have run into this when setting up the matrix tests, where the 1.18 build was failing.)

I recently attempted to install the latest version `go-wkhtmltopdf` on a Go 1.18 project and it gave no warning until compile time that it was incompatible. Adding the version here will (theoretically) present an appropriate warning/error that the module is not compatible with an older version of Go.